### PR TITLE
Fix ID3::Frame initialization.

### DIFF
--- a/lib/id3/frame.rb
+++ b/lib/id3/frame.rb
@@ -65,7 +65,7 @@ module ID3
     # ----------------------------------------------------------------------
 
     def initialize(name, version = '2.3.0', flags = 0, tag,  headerStartX, dataStartX, dataEndX )
-      super
+      super() # Don't pass the arguments through to the ordered hash.
 
       @name = name
       @headerStartX = headerStartX if headerStartX


### PR DESCRIPTION
When super is called with no arguments all the parameters get passed to the parent object. In the case of [Frame](https://github.com/tilo/ID3/blob/master/lib/id3/frame.rb#L67) < [RestrictedOrderedHash](https://github.com/tilo/ID3/blob/master/lib/helpers/restricted_ordered_hash.rb#L19) this causes an error since its parent does not accept any parameters.

```
rb(main):008:0> Limestone::Track.new('/Users/tom/Music/iTunes/iTunes Media/Music/Karma Kid/It\'s Always/It\'s Always.mp3')
ArgumentError: wrong number of arguments (7 for 0)
    from /Users/tom/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/id3-1.0.0.pre4/lib/helpers/restricted_ordered_hash.rb:19:in `initialize'
    from /Users/tom/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/id3-1.0.0.pre4/lib/id3/frame.rb:68:in `initialize'
    from /Users/tom/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/id3-1.0.0.pre4/lib/id3/tag2.rb:219:in `new'
    from /Users/tom/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/id3-1.0.0.pre4/lib/id3/tag2.rb:219:in `parse_frame_header'
    from /Users/tom/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/id3-1.0.0.pre4/lib/id3/tag2.rb:121:in `read_from_file'
    from /Users/tom/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/id3-1.0.0.pre4/lib/id3/audiofile.rb:57:in `initialize'
    from /Users/tom/ruby/limestone/lib/limestone/track.rb:4:in `new'
    from /Users/tom/ruby/limestone/lib/limestone/track.rb:4:in `initialize'
    from (irb):8:in `new'
    from (irb):8
    from /Users/tom/.rbenv/versions/1.9.3-p125/bin/irb:12:in `<main>'
```

Adding a parenthesis to the call to super causes no parameters to be passed. Not sure if this is due to a recent change in Ruby, not something I've come across before.
